### PR TITLE
Remove HEAD from limit_except directive in nginx conf files. 

### DIFF
--- a/config/nginx/virtual-servers/phpmyadmin.conf
+++ b/config/nginx/virtual-servers/phpmyadmin.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 

--- a/config/nginx/virtual-servers/rabbitmq.conf
+++ b/config/nginx/virtual-servers/rabbitmq.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 

--- a/config/nginx/virtual-servers/web56.conf
+++ b/config/nginx/virtual-servers/web56.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 

--- a/config/nginx/virtual-servers/web70.conf
+++ b/config/nginx/virtual-servers/web70.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 

--- a/config/nginx/virtual-servers/web71.conf
+++ b/config/nginx/virtual-servers/web71.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 

--- a/config/nginx/virtual-servers/web72.conf
+++ b/config/nginx/virtual-servers/web72.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 

--- a/config/nginx/virtual-servers/webubuntu71.conf
+++ b/config/nginx/virtual-servers/webubuntu71.conf
@@ -13,7 +13,8 @@ server {
 
     location / {
 
-        limit_except GET POST PUT HEAD DELETE OPTIONS PATCH {
+        # Allowing the GET method makes the HEAD method also allowed.
+        limit_except GET POST PUT DELETE OPTIONS PATCH {
              deny   all;
         }
 


### PR DESCRIPTION
Removing unnecessary http method. HEAD is implicit when GET is present.

For further reading about this from the nginx docs: <http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except>

