### PR TITLE
Correcting mysql 55 service

### DIFF
--- a/config/web56/mysql-client/my.cnf
+++ b/config/web56/mysql-client/my.cnf
@@ -17,7 +17,7 @@
 # escpecially if they contain "#" chars...
 # Remember to edit /etc/mysql/debian.cnf when changing the socket location.
 [client]
-host		= db57
+host		= db55
 port		= 3306
 socket		= /var/run/mysqld/mysqld.sock
 

--- a/custom-compose/db55.yml
+++ b/custom-compose/db55.yml
@@ -1,6 +1,6 @@
 version: '2.1'
 services:
-  db57:
+  db55:
     image: orangehrm/orangehrm-db-images:mysql-5.5
     expose:
       - "3306"
@@ -8,7 +8,7 @@ services:
       - ./custom-compose/config/db55:/etc/mysql
       - ./custom-compose/logs/mysql_logs/db55:/var/log
       - /etc/localtime:/etc/localtime
-      - mysql57:/var/lib/mysql
+      - mysql55:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: 1234
     networks:
@@ -18,4 +18,4 @@ services:
     container_name: dev_mysql_55
 
 volumes:
-  mysql57:
+  mysql55:


### PR DESCRIPTION
* Corrected Service and volume names for mysql 55 container
* set default db host to db55 in PHP 5.6 container